### PR TITLE
System-setup: explicitely call python in pip install

### DIFF
--- a/includes/actions/python/system-setup/action.yaml
+++ b/includes/actions/python/system-setup/action.yaml
@@ -77,7 +77,7 @@ runs:
 
   - name: Install latest pip
     run: |
-      pip install -U pip wheel virtualenv
+      python -m pip install -U pip wheel virtualenv
 
   - name: Install packaging tooling
     if: inputs.packaging-tools


### PR DESCRIPTION
This PR should fix Windows errors like this one (https://github.com/chipsalliance/f4pga-sdf-timing/actions/runs/3515343175/jobs/5890484667)