### PR TITLE
check-upload: do not run auditwheel on -any.whl

### DIFF
--- a/includes/actions/python/check-upload-publish-packages/action.yaml
+++ b/includes/actions/python/check-upload-publish-packages/action.yaml
@@ -47,7 +47,7 @@ runs:
         python -m zipfile -t $WHEEL
         python -m zipfile -l $WHEEL
         echo
-        if [ "$(uname)" = "Linux" -a $PYVER -eq 3 ]; then
+        if [ "$(uname)" = "Linux" -a $PYVER -eq 3 -a "${WHEEL: -8}" != "-any.whl" ]; then
           auditwheel show $WHEEL
         fi
         echo


### PR DESCRIPTION
running `auditwheel` on pure python packages fails with https://github.com/chipsalliance/f4pga-sdf-timing/actions/runs/3516074005/jobs/5892153129#step:9:75